### PR TITLE
Add the ability to delete a feature

### DIFF
--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -180,7 +180,9 @@ class Rollout
 
     def save(feature)
       @storage.set(key(feature.name), feature.serialize)
-      @storage.set(features_key, (features + [feature.name]).join(","))
+      if !features.include?(feature.name)
+        @storage.set(features_key, (features + [feature.name]).join(","))
+      end
     end
 
     def migrate?

--- a/lib/rollout.rb
+++ b/lib/rollout.rb
@@ -180,7 +180,7 @@ class Rollout
 
     def save(feature)
       @storage.set(key(feature.name), feature.serialize)
-      if !features.include?(feature.name)
+      if !features.include?(feature.name.to_sym)
         @storage.set(features_key, (features + [feature.name]).join(","))
       end
     end

--- a/spec/rollout_spec.rb
+++ b/spec/rollout_spec.rb
@@ -211,6 +211,11 @@ describe "Rollout" do
     @rollout.features.should be_include(:chat)
   end
 
+  it "keeps a distinct list of features" do
+    2.times { @rollout.activate(:chat) }
+    @rollout.features.select { |x| x == :chat }.size.should == 1
+  end
+
   describe "#get" do
     before do
       @rollout.activate_percentage(:chat, 10)


### PR DESCRIPTION
This would pull in the ability to delete a feature from the @ainsleyc fork. We need the ability to cleanup unused feature flags in the hosted help desk and this would save us directly editing Redis.
